### PR TITLE
[docker] use `--no-cache-dir` flag to `pip` in dockerfiles to save space

### DIFF
--- a/apps/InfluxdbApp/docker/influxdb-amd64
+++ b/apps/InfluxdbApp/docker/influxdb-amd64
@@ -12,7 +12,7 @@ MAINTAINER rst
 
 # install openmtc dependencies
 COPY tmp/$MOD_NAME-dependencies.txt /tmp/requirements.txt
-RUN pip install --upgrade --requirement /tmp/requirements.txt
+RUN pip install --no-cache-dir --upgrade --requirement /tmp/requirements.txt
 
 # install openmtc-influxdb
 COPY tmp/openmtc-$MOD_NAME.tar.gz /tmp/openmtc-$MOD_NAME.tar.gz

--- a/apps/InfluxdbApp/docker/influxdb-arm
+++ b/apps/InfluxdbApp/docker/influxdb-arm
@@ -12,7 +12,7 @@ MAINTAINER rst
 
 # install openmtc dependencies
 COPY tmp/$MOD_NAME-dependencies.txt /tmp/requirements.txt
-RUN pip install --upgrade --requirement /tmp/requirements.txt
+RUN pip install --no-cache-dir --upgrade --requirement /tmp/requirements.txt
 
 # install openmtc-influxdb
 COPY tmp/openmtc-$MOD_NAME.tar.gz /tmp/openmtc-$MOD_NAME.tar.gz

--- a/apps/InfluxdbApp/docker/influxdbapp-amd64
+++ b/apps/InfluxdbApp/docker/influxdbapp-amd64
@@ -12,7 +12,7 @@ MAINTAINER rst
 
 # install openmtc dependencies
 COPY tmp/$MOD_NAME-dependencies.txt /tmp/requirements.txt
-RUN pip install --upgrade --requirement /tmp/requirements.txt
+RUN pip install --no-cache-dir --upgrade --requirement /tmp/requirements.txt
 
 # install openmtc-influxdbapp
 COPY tmp/openmtc-$MOD_NAME.tar.gz /tmp/openmtc-$MOD_NAME.tar.gz

--- a/apps/InfluxdbApp/docker/influxdbapp-arm
+++ b/apps/InfluxdbApp/docker/influxdbapp-arm
@@ -12,7 +12,7 @@ MAINTAINER rst
 
 # install openmtc dependencies
 COPY tmp/$MOD_NAME-dependencies.txt /tmp/requirements.txt
-RUN pip install --upgrade --requirement /tmp/requirements.txt
+RUN pip install --no-cache-dir --upgrade --requirement /tmp/requirements.txt
 
 # install openmtc-influxdbapp
 COPY tmp/openmtc-$MOD_NAME.tar.gz /tmp/openmtc-$MOD_NAME.tar.gz

--- a/apps/OrionContextBroker/docker/orioncontextbroker-amd64
+++ b/apps/OrionContextBroker/docker/orioncontextbroker-amd64
@@ -12,7 +12,7 @@ MAINTAINER rst
 
 # install openmtc dependencies
 COPY tmp/$MOD_NAME-dependencies.txt /tmp/requirements.txt
-RUN pip install --upgrade --requirement /tmp/requirements.txt
+RUN pip install --no-cache-dir --upgrade --requirement /tmp/requirements.txt
 
 # install openmtc-orioncontextbroker
 COPY tmp/openmtc-$MOD_NAME.tar.gz /tmp/openmtc-$MOD_NAME.tar.gz

--- a/apps/OrionContextBroker/docker/orioncontextbroker-arm
+++ b/apps/OrionContextBroker/docker/orioncontextbroker-arm
@@ -12,7 +12,7 @@ MAINTAINER rst
 
 # install openmtc dependencies
 COPY tmp/$MOD_NAME-dependencies.txt /tmp/requirements.txt
-RUN pip install --upgrade --requirement /tmp/requirements.txt
+RUN pip install --no-cache-dir --upgrade --requirement /tmp/requirements.txt
 
 # install openmtc-orioncontextbroker
 COPY tmp/openmtc-$MOD_NAME.tar.gz /tmp/openmtc-$MOD_NAME.tar.gz

--- a/apps/csvInjector/docker/csvinjector-amd64
+++ b/apps/csvInjector/docker/csvinjector-amd64
@@ -12,7 +12,7 @@ MAINTAINER rst
 
 # install openmtc dependencies
 COPY tmp/$MOD_NAME-dependencies.txt /tmp/requirements.txt
-RUN pip install --upgrade --requirement /tmp/requirements.txt
+RUN pip install --no-cache-dir --upgrade --requirement /tmp/requirements.txt
 
 # install openmtc-csvinjector
 COPY tmp/openmtc-$MOD_NAME.tar.gz /tmp/openmtc-$MOD_NAME.tar.gz

--- a/apps/csvInjector/docker/csvinjector-arm
+++ b/apps/csvInjector/docker/csvinjector-arm
@@ -12,7 +12,7 @@ MAINTAINER rst
 
 # install openmtc dependencies
 COPY tmp/$MOD_NAME-dependencies.txt /tmp/requirements.txt
-RUN pip install --upgrade --requirement /tmp/requirements.txt
+RUN pip install --no-cache-dir --upgrade --requirement /tmp/requirements.txt
 
 # install openmtc-csvinjector
 COPY tmp/openmtc-$MOD_NAME.tar.gz /tmp/openmtc-$MOD_NAME.tar.gz

--- a/apps/mqttConnector/docker/mqttconnector-amd64
+++ b/apps/mqttConnector/docker/mqttconnector-amd64
@@ -12,7 +12,7 @@ MAINTAINER rst
 
 # install openmtc dependencies
 COPY tmp/$MOD_NAME-dependencies.txt /tmp/requirements.txt
-RUN pip install --upgrade --requirement /tmp/requirements.txt
+RUN pip install --no-cache-dir --upgrade --requirement /tmp/requirements.txt
 
 # install openmtc-mqttconnector
 COPY tmp/openmtc-$MOD_NAME.tar.gz /tmp/openmtc-$MOD_NAME.tar.gz

--- a/apps/mqttConnector/docker/mqttconnector-arm
+++ b/apps/mqttConnector/docker/mqttconnector-arm
@@ -12,7 +12,7 @@ MAINTAINER rst
 
 # install openmtc dependencies
 COPY tmp/$MOD_NAME-dependencies.txt /tmp/requirements.txt
-RUN pip install --upgrade --requirement /tmp/requirements.txt
+RUN pip install --no-cache-dir --upgrade --requirement /tmp/requirements.txt
 
 # install openmtc-mqttconnector
 COPY tmp/openmtc-$MOD_NAME.tar.gz /tmp/openmtc-$MOD_NAME.tar.gz

--- a/create-app-structure
+++ b/create-app-structure
@@ -522,7 +522,7 @@ MAINTAINER rst
 
 # install openmtc dependencies
 COPY tmp/\$MOD_NAME-dependencies.txt /tmp/requirements.txt
-RUN pip install --upgrade --requirement /tmp/requirements.txt
+RUN pip install --no-cache-dir --upgrade --requirement /tmp/requirements.txt
 
 # install openmtc-${PKG_NAME}
 COPY tmp/openmtc-\$MOD_NAME.tar.gz /tmp/openmtc-\$MOD_NAME.tar.gz

--- a/docker/backend-amd64
+++ b/docker/backend-amd64
@@ -12,7 +12,7 @@ MAINTAINER rst/tgu
 
 # install openmtc dependencies
 COPY tmp/$MOD_NAME-dependencies.txt /tmp/requirements.txt
-RUN pip3 install --upgrade --requirement /tmp/requirements.txt
+RUN pip3 install --no-cache-dir --upgrade --requirement /tmp/requirements.txt
 
 # install openmtc-all
 COPY tmp/openmtc-$MOD_NAME.tar.gz /tmp/openmtc-$MOD_NAME.tar.gz

--- a/docker/backend-arm
+++ b/docker/backend-arm
@@ -12,7 +12,7 @@ MAINTAINER rst/tgu
 
 # install openmtc dependencies
 COPY tmp/$MOD_NAME-dependencies.txt /tmp/requirements.txt
-RUN pip3 install --upgrade --requirement /tmp/requirements.txt
+RUN pip3 install --no-cache-dir --upgrade --requirement /tmp/requirements.txt
 
 # install openmtc-all
 COPY tmp/openmtc-$MOD_NAME.tar.gz /tmp/openmtc-$MOD_NAME.tar.gz

--- a/docker/gateway-amd64
+++ b/docker/gateway-amd64
@@ -12,7 +12,7 @@ MAINTAINER rst/tgu
 
 # install openmtc dependencies
 COPY tmp/$MOD_NAME-dependencies.txt /tmp/requirements.txt
-RUN pip3 install --upgrade --requirement /tmp/requirements.txt
+RUN pip3 install --no-cache-dir --upgrade --requirement /tmp/requirements.txt
 
 # install openmtc-all
 COPY tmp/openmtc-$MOD_NAME.tar.gz /tmp/openmtc-$MOD_NAME.tar.gz

--- a/docker/gateway-arm
+++ b/docker/gateway-arm
@@ -12,7 +12,7 @@ MAINTAINER rst/tgu
 
 # install openmtc dependencies
 COPY tmp/$MOD_NAME-dependencies.txt /tmp/requirements.txt
-RUN pip3 install --upgrade --requirement /tmp/requirements.txt
+RUN pip3 install --no-cache-dir --upgrade --requirement /tmp/requirements.txt
 
 # install openmtc-all
 COPY tmp/openmtc-$MOD_NAME.tar.gz /tmp/openmtc-$MOD_NAME.tar.gz

--- a/docker/sdk-amd64
+++ b/docker/sdk-amd64
@@ -11,11 +11,11 @@ ENV MOD_NAME=sdk
 MAINTAINER rst/tgu
 
 # update pip to latest version
-RUN pip3 install --upgrade pip
+RUN pip3 install --no-cache-dir --upgrade pip
 
 # install openmtc dependencies
 COPY tmp/$MOD_NAME-dependencies.txt /tmp/requirements.txt
-RUN pip3 install --upgrade --requirement /tmp/requirements.txt
+RUN pip3 install --no-cache-dir --upgrade --requirement /tmp/requirements.txt
 
 # install openmtc-sdk
 COPY tmp/openmtc-$MOD_NAME.tar.gz /tmp/openmtc-$MOD_NAME.tar.gz

--- a/docker/sdk-arm
+++ b/docker/sdk-arm
@@ -11,11 +11,11 @@ ENV MOD_NAME=sdk
 MAINTAINER rst/tgu
 
 # update pip to latest version
-RUN pip3 install --upgrade pip setuptools
+RUN pip3 install --no-cache-dir --upgrade pip setuptools
 
 # install openmtc dependencies
 COPY tmp/$MOD_NAME-dependencies.txt /tmp/requirements.txt
-RUN pip3 install --upgrade --requirement /tmp/requirements.txt
+RUN pip3 install --no-cache-dir --upgrade --requirement /tmp/requirements.txt
 
 # install openmtc-sdk
 COPY tmp/openmtc-$MOD_NAME.tar.gz /tmp/openmtc-$MOD_NAME.tar.gz

--- a/ipes/CUL868IPE/docker/cul868ipe-amd64
+++ b/ipes/CUL868IPE/docker/cul868ipe-amd64
@@ -12,7 +12,7 @@ MAINTAINER rst
 
 # install openmtc dependencies
 COPY tmp/$MOD_NAME-dependencies.txt /tmp/requirements.txt
-RUN pip install --upgrade --requirement /tmp/requirements.txt
+RUN pip install --no-cache-dir --upgrade --requirement /tmp/requirements.txt
 
 # install openmtc-cul868ipe
 COPY tmp/openmtc-$MOD_NAME.tar.gz /tmp/openmtc-$MOD_NAME.tar.gz

--- a/ipes/CUL868IPE/docker/cul868ipe-arm
+++ b/ipes/CUL868IPE/docker/cul868ipe-arm
@@ -12,7 +12,7 @@ MAINTAINER rst
 
 # install openmtc dependencies
 COPY tmp/$MOD_NAME-dependencies.txt /tmp/requirements.txt
-RUN pip install --upgrade --requirement /tmp/requirements.txt
+RUN pip install --no-cache-dir --upgrade --requirement /tmp/requirements.txt
 
 # install openmtc-cul868ipe
 COPY tmp/openmtc-$MOD_NAME.tar.gz /tmp/openmtc-$MOD_NAME.tar.gz


### PR DESCRIPTION
using "--no-cache-dir" flag in pip install ,make sure downloaded packages
by pip don't cached on system . This is a best practice which make sure
to fetch from repo instead of using local cached one . Further , in case
of Docker Containers , by restricting caching , we can reduce image size.
In term of stats , it depends upon the number of python packages
multiplied by their respective size . e.g for heavy packages with a lot
of dependencies it reduce a lot by don't caching pip packages.

Further , more detail information can be found at

https://medium.com/sciforce/strategies-of-docker-images-optimization-2ca9cc5719b6

Signed-off-by: Pratik Raj <rajpratik71@gmail.com>